### PR TITLE
Add support for jitpack builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ To ignore tests use the phrase `Integration` in the test class name (e.g `TorInt
     }
 ```
 to the module config. This is useful for tests which would require a custom setup (e.g. require I2P installation) and/or take a long time for running (e.g. starting tor/i2p)
+
+### Importing as dependency
+If building on top of the Misq codebase, Misq and its modules can be added as a project dependency. See https://jitpack.io/#chimp1984/misq

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Misq
 
+[![Release](https://jitpack.io/v/chimp1984/misq.svg)](https://jitpack.io/#chimp1984/misq)
+
 [![Build Status](https://travis-ci.org/github/chimp1984/misq.svg?branch=master)](https://travis-ci.org/github/chimp1984/misq)
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configure(rootProject) {
 
 configure(subprojects) {
     apply plugin: 'java'
+    apply plugin: 'maven-publish' // Needed for jitpack build, see https://jitpack.io/docs/BUILDING/
     apply plugin: 'com.google.osdetector'
 
     sourceCompatibility = 1.10
@@ -83,6 +84,14 @@ configure(subprojects) {
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
+    }
+
+    publishing {
+        publications {
+            myDistribution(MavenPublication) {
+                artifact jar
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Add plugin and configuration needed to integrate with jitpack.

The artifacts can now be built by jitpack (per commit / per branch / per release / etc). They can then be defined as dependencies in other projects, similar to https://jitpack.io/#cd2357/misq/a3bae94a47

This allows the data model and relevant presentation layer classes to be easily imported and used in other projects.